### PR TITLE
Use the async:: prefix consistenly.

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ inline /*<some_awaitable_type>*/ read_file_async()
 int main()
 {
     async::event_signal done{};
-    async::awaitable_then(read_file_async(), [&done](awaitable_result<std::string> result)
+    async::awaitable_then(read_file_async(), [&done](async::awaitable_result<std::string> result)
         {
             printf("%s\n", result().c_str());
             done.set();
@@ -73,7 +73,7 @@ inline /*<some_awaitable_type>*/ read_file_async()
 std::future<std::string> read_file_future()
 {
     std::shared_ptr<std::promise<std::string>> promise{ std::make_shared<std::promise<std::string>>() };
-    async::awaitable_then(read_file_async(), [promise](awaitable_result<std::string> result)
+    async::awaitable_then(read_file_async(), [promise](async::awaitable_result<std::string> result)
         {
             try
             {

--- a/test/task_tests.cpp
+++ b/test/task_tests.cpp
@@ -98,7 +98,7 @@ TEST_CASE("task<void>.await_suspend() does not run continuation when task is sus
     auto continuation = [&run](async::awaitable_result<void>) { run = true; };
 
     // Act
-    awaitable_then(task, continuation);
+    async::awaitable_then(task, continuation);
 
     // Assert
     REQUIRE(!run);
@@ -129,7 +129,7 @@ TEST_CASE("task<void>.await_suspend() runs continuation when task completes")
     async::task<void> task{ task_void_co_await(suspend_to_paused_callback_thread_awaitable_void{ callbackThread }) };
     async::event_signal done{};
     auto continuation = [&done](async::awaitable_result<void>) { done.set(); };
-    awaitable_then(task, continuation);
+    async::awaitable_then(task, continuation);
 
     // Act
     callbackThread.resume();
@@ -172,7 +172,7 @@ TEST_CASE("task<void>.await_suspend() does not run continuation before leaving c
         scopeDestroyedDuringCompletion = scopeDestroyed;
         done.set();
     };
-    awaitable_then(task, continuation);
+    async::awaitable_then(task, continuation);
 
     // Act
     callbackThread.resume();
@@ -354,7 +354,7 @@ TEST_CASE("task<T>.await_suspend() does not run continuation when task is suspen
     auto continuation = [&run](async::awaitable_result<int>) { run = true; };
 
     // Act
-    awaitable_then(task, continuation);
+    async::awaitable_then(task, continuation);
 
     // Assert
     REQUIRE(!run);
@@ -390,7 +390,7 @@ TEST_CASE("task<T>.await_suspend() runs continuation when task completes")
         suspend_to_paused_callback_thread_awaitable_value{ callbackThread, unusedValue }) };
     async::event_signal done{};
     auto continuation = [&done](async::awaitable_result<int>) { done.set(); };
-    awaitable_then(task, continuation);
+    async::awaitable_then(task, continuation);
 
     // Act
     callbackThread.resume();
@@ -424,7 +424,7 @@ TEST_CASE("task<T>.await_suspend() does not run continuation before leaving coro
         scopeDestroyedDuringCompletion = scopeDestroyed;
         done.set();
     };
-    awaitable_then(task, continuation);
+    async::awaitable_then(task, continuation);
 
     // Act
     callbackThread.resume();
@@ -584,7 +584,7 @@ TEST_CASE("task<T&>.await_suspend() does not run continuation when task is suspe
     auto continuation = [&run](async::awaitable_result<int&>) { run = true; };
 
     // Act
-    awaitable_then(task, continuation);
+    async::awaitable_then(task, continuation);
 
     // Assert
     REQUIRE(!run);
@@ -600,7 +600,7 @@ TEST_CASE("task<T&>.await_suspend() runs continuation when task completes")
         suspend_to_paused_callback_thread_awaitable_value<int&>{ callbackThread, unusedValue }) };
     async::event_signal done{};
     auto continuation = [&done](async::awaitable_result<int&>) { done.set(); };
-    awaitable_then(task, continuation);
+    async::awaitable_then(task, continuation);
 
     // Act
     callbackThread.resume();
@@ -624,7 +624,7 @@ TEST_CASE("task<T&>.await_suspend() does not run continuation before leaving cor
         scopeDestroyedDuringCompletion = scopeDestroyed;
         done.set();
     };
-    awaitable_then(task, continuation);
+    async::awaitable_then(task, continuation);
 
     // Act
     callbackThread.resume();


### PR DESCRIPTION
Use this prefix even when the namespace can be found due to argument-dependent lookup.