### PR TITLE
Fix a small race condition in awaitable_get.

### DIFF
--- a/include/async/awaitable_then.h
+++ b/include/async/awaitable_then.h
@@ -38,7 +38,6 @@ namespace async::details
             }
 
             continuation(std::move(result));
-
             co_return;
         }
     };


### PR DESCRIPTION
A coroutine_handle may be destroyed only when suspended. Wait until final_suspend's awaitable has returned false from await_ready (i.e., entered await_supend) to ensure the coroutine_handle is not destroyed just before the task finally suspends.