### PR TITLE
Use std::memory_order syntax compatible with C++20.

### DIFF
--- a/include/async/atomic_acq_rel.h
+++ b/include/async/atomic_acq_rel.h
@@ -6,8 +6,8 @@
 
 namespace async::details
 {
-    // Like std::atomic, but defaults to std::memory_order::memory_order_acq_rel (or memory_order_acquire or
-    // memory_order_release, as appropriate) rather than memory_order_seq_cst.
+    // Like std::atomic, but defaults to std::memory_order_acq_rel (or memory_order_acquire or memory_order_release,
+    // as appropriate) rather than memory_order_seq_cst.
     // Does not include some parts of std::atomic not currently used by callers.
     template <typename T>
     struct atomic_acq_rel final
@@ -38,56 +38,49 @@ namespace async::details
         }
 
         operator T() const noexcept { return std::forward<T>(load()); }
+
         operator T() const volatile noexcept { return std::forward<T>(load()); }
 
-        void store(T desired) noexcept
-        {
-            m_value.store(std::forward<T>(desired), std::memory_order::memory_order_release);
-        }
+        void store(T desired) noexcept { m_value.store(std::forward<T>(desired), std::memory_order_release); }
 
-        void store(T desired) volatile noexcept
-        {
-            m_value.store(std::forward<T>(desired, std::memory_order::memory_order_release));
-        }
+        void store(T desired) volatile noexcept { m_value.store(std::forward<T>(desired, std::memory_order_release)); }
 
-        T load() const noexcept { return std::forward<T>(m_value.load(std::memory_order::memory_order_acquire)); }
-        T load() const volatile noexcept
-        {
-            return std::forward<T>(m_value.load(std::memory_order::memory_order_acquire));
-        }
+        T load() const noexcept { return std::forward<T>(m_value.load(std::memory_order_acquire)); }
+
+        T load() const volatile noexcept { return std::forward<T>(m_value.load(std::memory_order_acquire)); }
 
         T exchange(T desired) noexcept
         {
-            return std::forward<T>(m_value.exchange(std::forward<T>(desired), std::memory_order::memory_order_acq_rel));
+            return std::forward<T>(m_value.exchange(std::forward<T>(desired), std::memory_order_acq_rel));
         }
 
         T exchange(T desired) volatile noexcept
         {
-            return std::forward<T>(m_value.exchange(std::forward<T>(desired), std::memory_order::memory_order_acq_rel));
+            return std::forward<T>(m_value.exchange(std::forward<T>(desired), std::memory_order_acq_rel));
         }
 
         bool compare_exchange_weak(T& expected, T desired) noexcept
         {
             return m_value.compare_exchange_weak(
-                std::forward<T&>(expected), std::forward<T>(desired), std::memory_order::memory_order_acq_rel);
+                std::forward<T&>(expected), std::forward<T>(desired), std::memory_order_acq_rel);
         }
 
         bool compare_exchange_weak(T& expected, T desired) volatile noexcept
         {
             return m_value.compare_exchange_weak(
-                std::forward<T&>(expected), std::forward<T>(desired), std::memory_order::memory_order_acq_rel);
+                std::forward<T&>(expected), std::forward<T>(desired), std::memory_order_acq_rel);
         }
 
         bool compare_exchange_strong(T& expected, T desired) noexcept
         {
             return m_value.compare_exchange_strong(
-                std::forward<T&>(expected), std::forward<T>(desired), std::memory_order::memory_order_acq_rel);
+                std::forward<T&>(expected), std::forward<T>(desired), std::memory_order_acq_rel);
         }
 
         bool compare_exchange_strong(T& expected, T desired) volatile noexcept
         {
             return m_value.compare_exchange_strong(
-                std::forward<T&>(expected), std::forward<T>(desired), std::memory_order::memory_order_acq_rel);
+                std::forward<T&>(expected), std::forward<T>(desired), std::memory_order_acq_rel);
         }
 
     private:


### PR DESCRIPTION
The definition of std::memory_order changed in C++20; use the subset of the syntax that works with both C++17 and C++20.