### PR TITLE
Static analysis cleanup (part 2 of 2)

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -9,7 +9,7 @@ insert_final_newline = true
 trim_trailing_whitespace = true
 
 ; imperative languages use a different indent_size
-[*.{cpp,def,h,idl}]
+[*.{cpp,h}]
 indent_size = 4
 
 ; don't fight VS
@@ -32,12 +32,3 @@ insert_final_newline = false
 ; don't fight Git
 [.gitmodules]
 indent_style = tab
-
-; don't fight NuGet tooling
-[packages.config]
-charset = utf-8-bom
-insert_final_newline = false
-
-; don't fight NuGet tooling
-[packages.lock.json]
-insert_final_newline = false

--- a/include/async/awaitable_get.h
+++ b/include/async/awaitable_get.h
@@ -18,7 +18,7 @@ namespace async::details
     {
         using promise_type = get_task_promise<T>;
 
-        explicit get_task(std::coroutine_handle<get_task_promise<T>> handle) : m_handle{ handle } {}
+        explicit get_task(std::coroutine_handle<get_task_promise<T>> handle) noexcept : m_handle{ handle } {}
 
         get_task(const get_task&) = delete;
         get_task(get_task&&) noexcept = delete;
@@ -51,7 +51,7 @@ namespace async::details
     template <typename T>
     struct get_task_promise final
     {
-        get_task_promise() : m_result{}, m_done{} {}
+        get_task_promise() noexcept : m_result{}, m_done{} {}
 
         get_task<T> get_return_object()
         {

--- a/include/async/awaitable_result.h
+++ b/include/async/awaitable_result.h
@@ -70,7 +70,7 @@ namespace async
             }
         }
 
-        void set_value(T value)
+        void set_value(T value) noexcept
         {
             new (std::addressof(m_storage.value)) possible_reference{ std::forward<T>(value) };
             m_storageType = result_union_type::value;

--- a/include/async/task_canceled.h
+++ b/include/async/task_canceled.h
@@ -6,6 +6,6 @@ namespace async
 {
     struct task_canceled : std::exception
     {
-        [[nodiscard]] const char* what() const override { return "task canceled"; }
+        [[nodiscard]] const char* what() const noexcept override { return "task canceled"; }
     };
 }

--- a/test/task_completion_source_tests.cpp
+++ b/test/task_completion_source_tests.cpp
@@ -91,6 +91,192 @@ TEST_CASE("task_completion_source<void>.try_set_value() returns true when not ye
 {
     // Arrange
     async::task_completion_source<void> promise{};
+    std::exception_ptr ignore{};
+
+    // Act
+    bool result{ promise.try_set_value(ignore) };
+
+    // Assert
+    REQUIRE(result);
+}
+
+TEST_CASE("task_completion_source<void>.try_set_value() sets completionException to empty when no completion exists")
+{
+    // Arrange
+    async::task_completion_source<void> promise{};
+    std::exception_ptr completionException{ std::make_exception_ptr(std::runtime_error{ "" }) };
+
+    // Act
+    std::ignore = promise.try_set_value(completionException);
+
+    // Assert
+    REQUIRE(!completionException);
+}
+
+TEST_CASE("task_completion_source<void>.try_set_value() makes its task ready")
+{
+    // Arrange
+    async::task_completion_source<void> promise{};
+    async::task<void> task{ promise.task() };
+    std::exception_ptr ignore{};
+
+    // Act
+    if (!promise.try_set_value(ignore))
+    {
+        throw std::runtime_error{ "Precondition failed." };
+    }
+
+    // Assert
+    REQUIRE(task.await_ready());
+}
+
+TEST_CASE("task_completion_source<void>.try_set_value() resumes a coroutine suspended on its task")
+{
+    // Arrange
+    async::task_completion_source<void> promise{};
+    async::event_signal done{};
+    co_await_void_finally_set_signal(promise.task(), done);
+    std::exception_ptr ignore{};
+
+    // Act
+    if (!promise.try_set_value(ignore))
+    {
+        throw std::runtime_error{ "Precondition failed." };
+    }
+
+    // Assert
+    REQUIRE(done.wait_for(std::chrono::seconds{ 1 }));
+}
+
+TEST_CASE("task_completion_source<void>.try_set_value() makes its task not throw on await_resume().")
+{
+    // Arrange
+    async::task_completion_source<void> promise{};
+    async::task<void> task{ promise.task() };
+    std::exception_ptr ignore{};
+
+    // Act
+    if (!promise.try_set_value(ignore))
+    {
+        throw std::runtime_error{ "Precondition failed." };
+    }
+
+    // Assert
+    REQUIRE_NOTHROW(task.await_resume());
+}
+
+TEST_CASE("task_completion_source<void>.try_set_value() sets completionException to empty when completion succeeds")
+{
+    // Arrange
+    async::task_completion_source<void> promise{};
+    async::event_signal done{};
+    co_await_void_finally_set_signal(promise.task(), done);
+    std::exception_ptr completionException{ std::make_exception_ptr(std::runtime_error{ "" }) };
+
+    // Act
+    std::ignore = promise.try_set_value(completionException);
+
+    // Assert
+    if (!done.is_set())
+    {
+        throw std::runtime_error{ "Precondition failed." };
+    }
+
+    REQUIRE(!completionException);
+}
+
+namespace
+{
+    struct co_await_void_propagates_unhandled_exception_task final
+    {
+        struct promise_type final
+        {
+            constexpr co_await_void_propagates_unhandled_exception_task get_return_object() const noexcept
+            {
+                return {};
+            }
+
+            constexpr std::suspend_never initial_suspend() const noexcept { return {}; }
+            void unhandled_exception() const { std::rethrow_exception(std::current_exception()); }
+            constexpr void return_void() const noexcept {}
+            constexpr std::suspend_never final_suspend() const noexcept { return {}; }
+        };
+    };
+
+    co_await_void_propagates_unhandled_exception_task co_await_void_propagates_unhandled_exception(
+        async::task<void>&& awaitable, std::exception_ptr exception)
+    {
+        try
+        {
+            co_await std::move(awaitable);
+        }
+        catch (...)
+        {
+        }
+
+        std::rethrow_exception(exception);
+    }
+}
+
+TEST_CASE("task_completion_source<void>.try_set_value() returns false when completion unhandled_exception throws")
+{
+    // Arrange
+    async::task_completion_source<void> promise{};
+    std::exception_ptr expectedCompletionException{ std::make_exception_ptr(std::runtime_error{ "" }) };
+    co_await_void_propagates_unhandled_exception(promise.task(), expectedCompletionException);
+    std::exception_ptr ignore{};
+
+    // Act
+    bool result{ promise.try_set_value(ignore) };
+
+    // Assert
+    REQUIRE(!result);
+}
+
+namespace
+{
+    void rethrow(std::exception_ptr exception) { std::rethrow_exception(exception); }
+}
+
+TEST_CASE("task_completion_source<void>.try_set_value() sets completionException when completion unhandled_exception "
+          "throws")
+{
+    // Arrange
+    async::task_completion_source<void> promise{};
+    std::runtime_error expected{ "expected" };
+    co_await_void_propagates_unhandled_exception(promise.task(), std::make_exception_ptr(expected));
+    std::exception_ptr actual{};
+
+    // Act
+    std::ignore = promise.try_set_value(actual);
+
+    // Assert
+    REQUIRE_THROWS_MATCHES(rethrow(actual), std::runtime_error, Catch::Matchers::Message(expected.what()));
+}
+
+TEST_CASE("task_completion_source<void>.try_set_value() returns false if called a second time.")
+{
+    // Arrange
+    async::task_completion_source<void> promise{};
+    async::task<void> task{ promise.task() };
+    std::exception_ptr ignore{};
+
+    if (!promise.try_set_value(ignore))
+    {
+        throw std::runtime_error{ "Precondition failed." };
+    }
+
+    // Act
+    bool result{ promise.try_set_value(ignore) };
+
+    // Assert
+    REQUIRE(!result);
+}
+
+TEST_CASE("task_completion_source<void>.try_set_value() deprecated overload returns true when not yet completed")
+{
+    // Arrange
+    async::task_completion_source<void> promise{};
 
     // Act
     bool result{ promise.try_set_value() };
@@ -99,7 +285,7 @@ TEST_CASE("task_completion_source<void>.try_set_value() returns true when not ye
     REQUIRE(result);
 }
 
-TEST_CASE("task_completion_source<void>.try_set_value() makes its task ready")
+TEST_CASE("task_completion_source<void>.try_set_value() deprecated overload makes its task ready")
 {
     // Arrange
     async::task_completion_source<void> promise{};
@@ -115,7 +301,7 @@ TEST_CASE("task_completion_source<void>.try_set_value() makes its task ready")
     REQUIRE(task.await_ready());
 }
 
-TEST_CASE("task_completion_source<void>.try_set_value() resumes a coroutine suspended on its task")
+TEST_CASE("task_completion_source<void>.try_set_value() deprecated overload resumes a coroutine suspended on its task")
 {
     // Arrange
     async::task_completion_source<void> promise{};
@@ -132,7 +318,8 @@ TEST_CASE("task_completion_source<void>.try_set_value() resumes a coroutine susp
     REQUIRE(done.wait_for(std::chrono::seconds{ 1 }));
 }
 
-TEST_CASE("task_completion_source<void>.try_set_value() makes its task not throw on await_resume().")
+TEST_CASE("task_completion_source<void>.try_set_value() deprecated overload makes its task not throw on "
+          "await_resume().")
 {
     // Arrange
     async::task_completion_source<void> promise{};
@@ -148,11 +335,12 @@ TEST_CASE("task_completion_source<void>.try_set_value() makes its task not throw
     REQUIRE_NOTHROW(task.await_resume());
 }
 
-TEST_CASE("task_completion_source<void>.try_set_value() returns false if called a second time.")
+TEST_CASE("task_completion_source<void>.try_set_value() deprecated overload returns false if called a second time.")
 {
     // Arrange
     async::task_completion_source<void> promise{};
     async::task<void> task{ promise.task() };
+
     if (!promise.try_set_value())
     {
         throw std::runtime_error{ "Precondition failed." };
@@ -240,6 +428,181 @@ TEST_CASE("task_completion_source<void>.try_set_exception() returns false if the
     async::task_completion_source<void> promise{};
     async::task<void> task{ promise.task() };
     std::exception_ptr empty{};
+    std::exception_ptr ignore{};
+
+    // Act
+    bool result{ promise.try_set_exception(empty, ignore) };
+
+    // Assert
+    REQUIRE(!result);
+}
+
+TEST_CASE("task_completion_source<void>.try_set_exception() returns true when not yet completed")
+{
+    // Arrange
+    async::task_completion_source<void> promise{};
+    std::exception_ptr exception{ std::make_exception_ptr(std::runtime_error{ "" }) };
+    std::exception_ptr ignore{};
+
+    // Act
+    bool result{ promise.try_set_exception(exception, ignore) };
+
+    // Assert
+    REQUIRE(result);
+}
+
+TEST_CASE("task_completion_source<void>.try_set_exception() sets completionException to empty when no completion "
+          "exists")
+{
+    // Arrange
+    async::task_completion_source<void> promise{};
+    std::exception_ptr exception{ std::make_exception_ptr(std::runtime_error{ "" }) };
+    std::exception_ptr completionException{ std::make_exception_ptr(std::runtime_error{ "" }) };
+
+    // Act
+    std::ignore = promise.try_set_exception(exception, completionException);
+
+    // Assert
+    REQUIRE(!completionException);
+}
+
+TEST_CASE("task_completion_source<void>.try_set_exception() makes its task ready")
+{
+    // Arrange
+    async::task_completion_source<void> promise{};
+    async::task<void> task{ promise.task() };
+    std::exception_ptr exception{ std::make_exception_ptr(std::runtime_error{ "" }) };
+    std::exception_ptr ignore{};
+
+    // Act
+    if (!promise.try_set_exception(exception, ignore))
+    {
+        throw std::runtime_error{ "Precondition failed." };
+    }
+
+    // Assert
+    REQUIRE(task.await_ready());
+}
+
+TEST_CASE("task_completion_source<void>.try_set_exception() resumes a coroutine suspended on its task")
+{
+    // Arrange
+    async::task_completion_source<void> promise{};
+    async::event_signal done{};
+    co_await_void_finally_set_signal(promise.task(), done);
+    std::exception_ptr exception{ std::make_exception_ptr(std::runtime_error{ "" }) };
+    std::exception_ptr ignore{};
+
+    // Act
+    if (!promise.try_set_exception(exception, ignore))
+    {
+        throw std::runtime_error{ "Precondition failed." };
+    }
+
+    // Assert
+    REQUIRE(done.wait_for(std::chrono::seconds{ 1 }));
+}
+
+TEST_CASE("task_completion_source<void>.try_set_exception() makes its task throw on await_resume().")
+{
+    // Arrange
+    async::task_completion_source<void> promise{};
+    async::task<void> task{ promise.task() };
+    std::runtime_error expected{ "expected" };
+    std::exception_ptr exception{ std::make_exception_ptr(expected) };
+    std::exception_ptr ignore{};
+
+    // Act
+    if (!promise.try_set_exception(exception, ignore))
+    {
+        throw std::runtime_error{ "Precondition failed." };
+    }
+
+    // Assert
+    REQUIRE_THROWS_MATCHES(task.await_resume(), std::runtime_error, Catch::Matchers::Message(expected.what()));
+}
+
+TEST_CASE("task_completion_source<void>.try_set_exception() sets completionException to empty when completion succeeds")
+{
+    // Arrange
+    async::task_completion_source<void> promise{};
+    async::event_signal done{};
+    co_await_void_finally_set_signal(promise.task(), done);
+    std::exception_ptr exception{ std::make_exception_ptr(std::runtime_error{ "" }) };
+    std::exception_ptr completionException{ std::make_exception_ptr(std::runtime_error{ "" }) };
+
+    // Act
+    std::ignore = promise.try_set_exception(exception, completionException);
+
+    // Assert
+    if (!done.is_set())
+    {
+        throw std::runtime_error{ "Precondition failed." };
+    }
+
+    REQUIRE(!completionException);
+}
+
+TEST_CASE("task_completion_source<void>.try_set_exception() sets completionException when completion "
+          "unhandled_exception throws")
+{
+    // Arrange
+    async::task_completion_source<void> promise{};
+    std::runtime_error expected{ "expected" };
+    co_await_void_propagates_unhandled_exception(promise.task(), std::make_exception_ptr(expected));
+    std::exception_ptr exception{ std::make_exception_ptr(std::runtime_error{ "bad" }) };
+    std::exception_ptr actual{};
+
+    // Act
+    std::ignore = promise.try_set_exception(exception, actual);
+
+    // Assert
+    REQUIRE_THROWS_MATCHES(rethrow(actual), std::runtime_error, Catch::Matchers::Message(expected.what()));
+}
+
+TEST_CASE("task_completion_source<void>.try_set_exception() returns false when completion unhandled_exception throws")
+{
+    // Arrange
+    async::task_completion_source<void> promise{};
+    std::exception_ptr expectedCompletionException{ std::make_exception_ptr(std::runtime_error{ "" }) };
+    co_await_void_propagates_unhandled_exception(promise.task(), expectedCompletionException);
+    std::exception_ptr exception{ std::make_exception_ptr(std::runtime_error{ "" }) };
+    std::exception_ptr ignore{};
+
+    // Act
+    bool result{ promise.try_set_exception(exception, ignore) };
+
+    // Assert
+    REQUIRE(!result);
+}
+
+TEST_CASE("task_completion_source<void>.try_set_exception() returns false if called a second time.")
+{
+    // Arrange
+    async::task_completion_source<void> promise{};
+    async::task<void> task{ promise.task() };
+    std::exception_ptr exception{ std::make_exception_ptr(std::runtime_error{ "" }) };
+    std::exception_ptr ignore{};
+
+    if (!promise.try_set_exception(exception, ignore))
+    {
+        throw std::runtime_error{ "Precondition failed." };
+    }
+
+    // Act
+    bool result{ promise.try_set_exception(exception, ignore) };
+
+    // Assert
+    REQUIRE(!result);
+}
+
+TEST_CASE("task_completion_source<void>.try_set_exception() deprecated overload returns false if the exception_ptr is "
+          "empty")
+{
+    // Arrange
+    async::task_completion_source<void> promise{};
+    async::task<void> task{ promise.task() };
+    std::exception_ptr empty{};
 
     // Act
     bool result{ promise.try_set_exception(empty) };
@@ -248,7 +611,7 @@ TEST_CASE("task_completion_source<void>.try_set_exception() returns false if the
     REQUIRE(!result);
 }
 
-TEST_CASE("task_completion_source<void>.try_set_exception() returns true when not yet completed")
+TEST_CASE("task_completion_source<void>.try_set_exception() deprecated overload returns true when not yet completed")
 {
     // Arrange
     async::task_completion_source<void> promise{};
@@ -261,7 +624,7 @@ TEST_CASE("task_completion_source<void>.try_set_exception() returns true when no
     REQUIRE(result);
 }
 
-TEST_CASE("task_completion_source<void>.try_set_exception() makes its task ready")
+TEST_CASE("task_completion_source<void>.try_set_exception() deprecated overload makes its task ready")
 {
     // Arrange
     async::task_completion_source<void> promise{};
@@ -278,7 +641,8 @@ TEST_CASE("task_completion_source<void>.try_set_exception() makes its task ready
     REQUIRE(task.await_ready());
 }
 
-TEST_CASE("task_completion_source<void>.try_set_exception() resumes a coroutine suspended on its task")
+TEST_CASE("task_completion_source<void>.try_set_exception() deprecated overload resumes a coroutine suspended on its "
+          "task")
 {
     // Arrange
     async::task_completion_source<void> promise{};
@@ -296,7 +660,8 @@ TEST_CASE("task_completion_source<void>.try_set_exception() resumes a coroutine 
     REQUIRE(done.wait_for(std::chrono::seconds{ 1 }));
 }
 
-TEST_CASE("task_completion_source<void>.try_set_exception() makes its task throw on await_resume().")
+TEST_CASE("task_completion_source<void>.try_set_exception() deprecated overload makes its task throw on "
+          "await_resume().")
 {
     // Arrange
     async::task_completion_source<void> promise{};
@@ -314,12 +679,13 @@ TEST_CASE("task_completion_source<void>.try_set_exception() makes its task throw
     REQUIRE_THROWS_MATCHES(task.await_resume(), std::runtime_error, Catch::Matchers::Message(expected.what()));
 }
 
-TEST_CASE("task_completion_source<void>.try_set_exception() returns false if called a second time.")
+TEST_CASE("task_completion_source<void>.try_set_exception() deprecated overload returns false if called a second time.")
 {
     // Arrange
     async::task_completion_source<void> promise{};
     async::task<void> task{ promise.task() };
     std::exception_ptr exception{ std::make_exception_ptr(std::runtime_error{ "" }) };
+
     if (!promise.try_set_exception(exception))
     {
         throw std::runtime_error{ "Precondition failed." };
@@ -422,6 +788,199 @@ TEST_CASE("task_completion_source<T>.try_set_value() returns true when not yet c
     // Arrange
     async::task_completion_source<int> promise{};
     constexpr int value{ 123 };
+    std::exception_ptr ignore{};
+
+    // Act
+    bool result{ promise.try_set_value(value, ignore) };
+
+    // Assert
+    REQUIRE(result);
+}
+
+TEST_CASE("task_completion_source<T>.try_set_value() sets completionException to empty when no completion exists")
+{
+    // Arrange
+    async::task_completion_source<int> promise{};
+    constexpr int value{ 123 };
+    std::exception_ptr completionException{ std::make_exception_ptr(std::runtime_error{ "" }) };
+
+    // Act
+    std::ignore = promise.try_set_value(value, completionException);
+
+    // Assert
+    REQUIRE(!completionException);
+}
+
+TEST_CASE("task_completion_source<T>.try_set_value() makes its task ready")
+{
+    // Arrange
+    async::task_completion_source<int> promise{};
+    async::task<int> task{ promise.task() };
+    constexpr int value{ 123 };
+    std::exception_ptr ignore{};
+
+    // Act
+    if (!promise.try_set_value(value, ignore))
+    {
+        throw std::runtime_error{ "Precondition failed." };
+    }
+
+    // Assert
+    REQUIRE(task.await_ready());
+}
+
+TEST_CASE("task_completion_source<T>.try_set_value() resumes a coroutine suspended on its task")
+{
+    // Arrange
+    async::task_completion_source<int> promise{};
+    async::event_signal done{};
+    co_await_value_finally_set_signal(promise.task(), done);
+    constexpr int value{ 123 };
+    std::exception_ptr ignore{};
+
+    // Act
+    if (!promise.try_set_value(value, ignore))
+    {
+        throw std::runtime_error{ "Precondition failed." };
+    }
+
+    // Assert
+    REQUIRE(done.wait_for(std::chrono::seconds{ 1 }));
+}
+
+TEST_CASE("task_completion_source<T>.try_set_value() makes its task return that value on await_resume().")
+{
+    // Arrange
+    async::task_completion_source<int> promise{};
+    async::task<int> task{ promise.task() };
+    constexpr int expected{ 123 };
+    std::exception_ptr ignore{};
+
+    // Act
+    if (!promise.try_set_value(expected, ignore))
+    {
+        throw std::runtime_error{ "Precondition failed." };
+    }
+
+    // Assert
+    REQUIRE(task.await_resume() == expected);
+}
+
+TEST_CASE("task_completion_source<T>.try_set_value() sets completionException to empty when completion succeeds")
+{
+    // Arrange
+    async::task_completion_source<int> promise{};
+    async::event_signal done{};
+    co_await_value_finally_set_signal(promise.task(), done);
+    constexpr int value{ 123 };
+    std::exception_ptr completionException{ std::make_exception_ptr(std::runtime_error{ "" }) };
+
+    // Act
+    std::ignore = promise.try_set_value(value, completionException);
+
+    // Assert
+    if (!done.is_set())
+    {
+        throw std::runtime_error{ "Precondition failed." };
+    }
+
+    REQUIRE(!completionException);
+}
+
+namespace
+{
+    struct co_await_value_propagates_unhandled_exception_task final
+    {
+        struct promise_type final
+        {
+            constexpr co_await_value_propagates_unhandled_exception_task get_return_object() const noexcept
+            {
+                return {};
+            }
+
+            constexpr std::suspend_never initial_suspend() const noexcept { return {}; }
+            void unhandled_exception() const { std::rethrow_exception(std::current_exception()); }
+            constexpr void return_value(int) const noexcept {}
+            constexpr std::suspend_never final_suspend() const noexcept { return {}; }
+        };
+    };
+
+    co_await_value_propagates_unhandled_exception_task co_await_value_propagates_unhandled_exception(
+        async::task<int>&& awaitable, std::exception_ptr exception)
+    {
+        int ignore{};
+
+        try
+        {
+            ignore = co_await std::move(awaitable);
+        }
+        catch (...)
+        {
+        }
+
+        std::rethrow_exception(exception);
+        co_return ignore; // Will never execute, but the compiler needs this line.
+    }
+}
+
+TEST_CASE("task_completion_source<T>.try_set_value() returns false when completion unhandled_exception throws")
+{
+    // Arrange
+    async::task_completion_source<int> promise{};
+    std::exception_ptr expectedCompletionException{ std::make_exception_ptr(std::runtime_error{ "" }) };
+    co_await_value_propagates_unhandled_exception(promise.task(), expectedCompletionException);
+    constexpr int value{ 123 };
+    std::exception_ptr ignore{};
+
+    // Act
+    bool result{ promise.try_set_value(value, ignore) };
+
+    // Assert
+    REQUIRE(!result);
+}
+
+TEST_CASE("task_completion_source<T>.try_set_value() sets completionException when completion unhandled_exception "
+          "throws")
+{
+    // Arrange
+    async::task_completion_source<int> promise{};
+    std::runtime_error expected{ "expected" };
+    co_await_value_propagates_unhandled_exception(promise.task(), std::make_exception_ptr(expected));
+    constexpr int value{ 123 };
+    std::exception_ptr actual{};
+
+    // Act
+    std::ignore = promise.try_set_value(value, actual);
+
+    // Assert
+    REQUIRE_THROWS_MATCHES(rethrow(actual), std::runtime_error, Catch::Matchers::Message(expected.what()));
+}
+
+TEST_CASE("task_completion_source<T>.try_set_value() returns false if called a second time.")
+{
+    // Arrange
+    async::task_completion_source<int> promise{};
+    async::task<int> task{ promise.task() };
+    constexpr int value{ 123 };
+    std::exception_ptr ignore{};
+
+    if (!promise.try_set_value(value, ignore))
+    {
+        throw std::runtime_error{ "Precondition failed." };
+    }
+
+    // Act
+    bool result{ promise.try_set_value(value, ignore) };
+
+    // Assert
+    REQUIRE(!result);
+}
+
+TEST_CASE("task_completion_source<T>.try_set_value() deprecated overload returns true when not yet completed")
+{
+    // Arrange
+    async::task_completion_source<int> promise{};
+    constexpr int value{ 123 };
 
     // Act
     bool result{ promise.try_set_value(value) };
@@ -430,7 +989,7 @@ TEST_CASE("task_completion_source<T>.try_set_value() returns true when not yet c
     REQUIRE(result);
 }
 
-TEST_CASE("task_completion_source<T>.try_set_value() makes its task ready")
+TEST_CASE("task_completion_source<T>.try_set_value() deprecated overload makes its task ready")
 {
     // Arrange
     async::task_completion_source<int> promise{};
@@ -447,7 +1006,7 @@ TEST_CASE("task_completion_source<T>.try_set_value() makes its task ready")
     REQUIRE(task.await_ready());
 }
 
-TEST_CASE("task_completion_source<T>.try_set_value() resumes a coroutine suspended on its task")
+TEST_CASE("task_completion_source<T>.try_set_value() deprecated overload resumes a coroutine suspended on its task")
 {
     // Arrange
     async::task_completion_source<int> promise{};
@@ -465,7 +1024,8 @@ TEST_CASE("task_completion_source<T>.try_set_value() resumes a coroutine suspend
     REQUIRE(done.wait_for(std::chrono::seconds{ 1 }));
 }
 
-TEST_CASE("task_completion_source<T>.try_set_value() makes its task return that value on await_resume().")
+TEST_CASE("task_completion_source<T>.try_set_value() deprecated overload makes its task return that value on "
+          "await_resume().")
 {
     // Arrange
     async::task_completion_source<int> promise{};
@@ -482,12 +1042,13 @@ TEST_CASE("task_completion_source<T>.try_set_value() makes its task return that 
     REQUIRE(task.await_resume() == expected);
 }
 
-TEST_CASE("task_completion_source<T>.try_set_value() returns false if called a second time.")
+TEST_CASE("task_completion_source<T>.try_set_value() deprecated overload returns false if called a second time.")
 {
     // Arrange
     async::task_completion_source<int> promise{};
     async::task<int> task{ promise.task() };
     constexpr int value{ 123 };
+
     if (!promise.try_set_value(value))
     {
         throw std::runtime_error{ "Precondition failed." };
@@ -575,6 +1136,180 @@ TEST_CASE("task_completion_source<T>.try_set_exception() returns false if the ex
     async::task_completion_source<int> promise{};
     async::task<int> task{ promise.task() };
     std::exception_ptr empty{};
+    std::exception_ptr ignore{};
+
+    // Act
+    bool result{ promise.try_set_exception(empty, ignore) };
+
+    // Assert
+    REQUIRE(!result);
+}
+
+TEST_CASE("task_completion_source<T>.try_set_exception() returns true when not yet completed")
+{
+    // Arrange
+    async::task_completion_source<int> promise{};
+    std::exception_ptr exception{ std::make_exception_ptr(std::runtime_error{ "" }) };
+    std::exception_ptr ignore{};
+
+    // Act
+    bool result{ promise.try_set_exception(exception, ignore) };
+
+    // Assert
+    REQUIRE(result);
+}
+
+TEST_CASE("task_completion_source<T>.try_set_exception() sets completionException to empty when no completion exists")
+{
+    // Arrange
+    async::task_completion_source<int> promise{};
+    std::exception_ptr exception{ std::make_exception_ptr(std::runtime_error{ "" }) };
+    std::exception_ptr completionException{ std::make_exception_ptr(std::runtime_error{ "" }) };
+
+    // Act
+    std::ignore = promise.try_set_exception(exception, completionException);
+
+    // Assert
+    REQUIRE(!completionException);
+}
+
+TEST_CASE("task_completion_source<T>.try_set_exception() makes its task ready")
+{
+    // Arrange
+    async::task_completion_source<int> promise{};
+    async::task<int> task{ promise.task() };
+    std::exception_ptr exception{ std::make_exception_ptr(std::runtime_error{ "" }) };
+    std::exception_ptr ignore{};
+
+    // Act
+    if (!promise.try_set_exception(exception, ignore))
+    {
+        throw std::runtime_error{ "Precondition failed." };
+    }
+
+    // Assert
+    REQUIRE(task.await_ready());
+}
+
+TEST_CASE("task_completion_source<T>.try_set_exception() resumes a coroutine suspended on its task")
+{
+    // Arrange
+    async::task_completion_source<int> promise{};
+    async::event_signal done{};
+    co_await_value_finally_set_signal(promise.task(), done);
+    std::exception_ptr exception{ std::make_exception_ptr(std::runtime_error{ "" }) };
+    std::exception_ptr ignore{};
+
+    // Act
+    if (!promise.try_set_exception(exception, ignore))
+    {
+        throw std::runtime_error{ "Precondition failed." };
+    }
+
+    // Assert
+    REQUIRE(done.wait_for(std::chrono::seconds{ 1 }));
+}
+
+TEST_CASE("task_completion_source<T>.try_set_exception() makes its task throw on await_resume().")
+{
+    // Arrange
+    async::task_completion_source<int> promise{};
+    async::task<int> task{ promise.task() };
+    std::runtime_error expected{ "expected" };
+    std::exception_ptr exception{ std::make_exception_ptr(expected) };
+    std::exception_ptr ignore{};
+
+    // Act
+    if (!promise.try_set_exception(exception, ignore))
+    {
+        throw std::runtime_error{ "Precondition failed." };
+    }
+
+    // Assert
+    REQUIRE_THROWS_MATCHES(task.await_resume(), std::runtime_error, Catch::Matchers::Message(expected.what()));
+}
+
+TEST_CASE("task_completion_source<T>.try_set_exception() sets completionException to empty when completion succeeds")
+{
+    // Arrange
+    async::task_completion_source<int> promise{};
+    async::event_signal done{};
+    co_await_value_finally_set_signal(promise.task(), done);
+    std::exception_ptr exception{ std::make_exception_ptr(std::runtime_error{ "" }) };
+    std::exception_ptr completionException{ std::make_exception_ptr(std::runtime_error{ "" }) };
+
+    // Act
+    std::ignore = promise.try_set_exception(exception, completionException);
+
+    // Assert
+    if (!done.is_set())
+    {
+        throw std::runtime_error{ "Precondition failed." };
+    }
+
+    REQUIRE(!completionException);
+}
+
+TEST_CASE("task_completion_source<T>.try_set_exception() sets completionException when completion "
+          "unhandled_exception throws")
+{
+    // Arrange
+    async::task_completion_source<int> promise{};
+    std::runtime_error expected{ "expected" };
+    co_await_value_propagates_unhandled_exception(promise.task(), std::make_exception_ptr(expected));
+    std::exception_ptr exception{ std::make_exception_ptr(std::runtime_error{ "bad" }) };
+    std::exception_ptr actual{};
+
+    // Act
+    std::ignore = promise.try_set_exception(exception, actual);
+
+    // Assert
+    REQUIRE_THROWS_MATCHES(rethrow(actual), std::runtime_error, Catch::Matchers::Message(expected.what()));
+}
+
+TEST_CASE("task_completion_source<T>.try_set_exception() returns false when completion unhandled_exception throws")
+{
+    // Arrange
+    async::task_completion_source<int> promise{};
+    std::exception_ptr expectedCompletionException{ std::make_exception_ptr(std::runtime_error{ "" }) };
+    co_await_value_propagates_unhandled_exception(promise.task(), expectedCompletionException);
+    std::exception_ptr exception{ std::make_exception_ptr(std::runtime_error{ "" }) };
+    std::exception_ptr ignore{};
+
+    // Act
+    bool result{ promise.try_set_exception(exception, ignore) };
+
+    // Assert
+    REQUIRE(!result);
+}
+
+TEST_CASE("task_completion_source<T>.try_set_exception() returns false if called a second time.")
+{
+    // Arrange
+    async::task_completion_source<int> promise{};
+    async::task<int> task{ promise.task() };
+    std::exception_ptr exception{ std::make_exception_ptr(std::runtime_error{ "" }) };
+    std::exception_ptr ignore{};
+
+    if (!promise.try_set_exception(exception, ignore))
+    {
+        throw std::runtime_error{ "Precondition failed." };
+    }
+
+    // Act
+    bool result{ promise.try_set_exception(exception, ignore) };
+
+    // Assert
+    REQUIRE(!result);
+}
+
+TEST_CASE("task_completion_source<T>.try_set_exception() deprecated overload returns false if the exception_ptr is "
+          "empty")
+{
+    // Arrange
+    async::task_completion_source<int> promise{};
+    async::task<int> task{ promise.task() };
+    std::exception_ptr empty{};
 
     // Act
     bool result{ promise.try_set_exception(empty) };
@@ -583,7 +1318,7 @@ TEST_CASE("task_completion_source<T>.try_set_exception() returns false if the ex
     REQUIRE(!result);
 }
 
-TEST_CASE("task_completion_source<T>.try_set_exception() returns true when not yet completed")
+TEST_CASE("task_completion_source<T>.try_set_exception() deprecated overload returns true when not yet completed")
 {
     // Arrange
     async::task_completion_source<int> promise{};
@@ -596,7 +1331,7 @@ TEST_CASE("task_completion_source<T>.try_set_exception() returns true when not y
     REQUIRE(result);
 }
 
-TEST_CASE("task_completion_source<T>.try_set_exception() makes its task ready")
+TEST_CASE("task_completion_source<T>.try_set_exception() deprecated overload makes its task ready")
 {
     // Arrange
     async::task_completion_source<int> promise{};
@@ -613,7 +1348,7 @@ TEST_CASE("task_completion_source<T>.try_set_exception() makes its task ready")
     REQUIRE(task.await_ready());
 }
 
-TEST_CASE("task_completion_source<T>.try_set_exception() resumes a coroutine suspended on its task")
+TEST_CASE("task_completion_source<T>.try_set_exception() deprecated overload resumes a coroutine suspended on its task")
 {
     // Arrange
     async::task_completion_source<int> promise{};
@@ -631,7 +1366,7 @@ TEST_CASE("task_completion_source<T>.try_set_exception() resumes a coroutine sus
     REQUIRE(done.wait_for(std::chrono::seconds{ 1 }));
 }
 
-TEST_CASE("task_completion_source<T>.try_set_exception() makes its task throw on await_resume().")
+TEST_CASE("task_completion_source<T>.try_set_exception() deprecated overload makes its task throw on await_resume().")
 {
     // Arrange
     async::task_completion_source<int> promise{};
@@ -649,12 +1384,13 @@ TEST_CASE("task_completion_source<T>.try_set_exception() makes its task throw on
     REQUIRE_THROWS_MATCHES(task.await_resume(), std::runtime_error, Catch::Matchers::Message(expected.what()));
 }
 
-TEST_CASE("task_completion_source<T>.try_set_exception() returns false if called a second time.")
+TEST_CASE("task_completion_source<T>.try_set_exception() deprecated overload returns false if called a second time.")
 {
     // Arrange
     async::task_completion_source<int> promise{};
     async::task<int> task{ promise.task() };
     std::exception_ptr exception{ std::make_exception_ptr(std::runtime_error{ "" }) };
+
     if (!promise.try_set_exception(exception))
     {
         throw std::runtime_error{ "Precondition failed." };
@@ -747,9 +1483,10 @@ TEST_CASE("task_completion_source<T&>.try_set_value() returns true when not yet 
     async::task_completion_source<int&> promise{};
     int storage{ 123 };
     int& value{ storage };
+    std::exception_ptr ignore{};
 
     // Act
-    bool result{ promise.try_set_value(value) };
+    bool result{ promise.try_set_value(value, ignore) };
 
     // Assert
     REQUIRE(result);
@@ -762,9 +1499,10 @@ TEST_CASE("task_completion_source<T&>.try_set_value() makes its task ready")
     async::task<int&> task{ promise.task() };
     int storage{ 123 };
     int& value{ storage };
+    std::exception_ptr ignore{};
 
     // Act
-    if (!promise.try_set_value(value))
+    if (!promise.try_set_value(value, ignore))
     {
         throw std::runtime_error{ "Precondition failed." };
     }
@@ -781,9 +1519,10 @@ TEST_CASE("task_completion_source<T&>.try_set_value() resumes a coroutine suspen
     co_await_value_finally_set_signal(promise.task(), done);
     int storage{ 123 };
     int& value{ storage };
+    std::exception_ptr ignore{};
 
     // Act
-    if (!promise.try_set_value(value))
+    if (!promise.try_set_value(value, ignore))
     {
         throw std::runtime_error{ "Precondition failed." };
     }
@@ -799,9 +1538,10 @@ TEST_CASE("task_completion_source<T&>.try_set_value() makes its task return that
     async::task<int&> task{ promise.task() };
     int storage{ 123 };
     int& expected{ storage };
+    std::exception_ptr ignore{};
 
     // Act
-    if (!promise.try_set_value(expected))
+    if (!promise.try_set_value(expected, ignore))
     {
         throw std::runtime_error{ "Precondition failed." };
     }
@@ -819,13 +1559,15 @@ TEST_CASE("task_completion_source<T&>.try_set_value() returns false if called a 
     async::task<int&> task{ promise.task() };
     int storage{ 123 };
     int& value{ storage };
-    if (!promise.try_set_value(value))
+    std::exception_ptr ignore{};
+
+    if (!promise.try_set_value(value, ignore))
     {
         throw std::runtime_error{ "Precondition failed." };
     }
 
     // Act
-    bool result{ promise.try_set_value(value) };
+    bool result{ promise.try_set_value(value, ignore) };
 
     // Assert
     REQUIRE(!result);
@@ -906,9 +1648,10 @@ TEST_CASE("task_completion_source<T&>.try_set_exception() returns false if the e
     async::task_completion_source<int&> promise{};
     async::task<int&> task{ promise.task() };
     std::exception_ptr empty{};
+    std::exception_ptr ignore{};
 
     // Act
-    bool result{ promise.try_set_exception(empty) };
+    bool result{ promise.try_set_exception(empty, ignore) };
 
     // Assert
     REQUIRE(!result);
@@ -919,9 +1662,10 @@ TEST_CASE("task_completion_source<T&>.try_set_exception() returns true when not 
     // Arrange
     async::task_completion_source<int&> promise{};
     std::exception_ptr exception{ std::make_exception_ptr(std::runtime_error{ "" }) };
+    std::exception_ptr ignore{};
 
     // Act
-    bool result{ promise.try_set_exception(exception) };
+    bool result{ promise.try_set_exception(exception, ignore) };
 
     // Assert
     REQUIRE(result);
@@ -933,9 +1677,10 @@ TEST_CASE("task_completion_source<T&>.try_set_exception() makes its task ready")
     async::task_completion_source<int&> promise{};
     async::task<int&> task{ promise.task() };
     std::exception_ptr exception{ std::make_exception_ptr(std::runtime_error{ "" }) };
+    std::exception_ptr ignore{};
 
     // Act
-    if (!promise.try_set_exception(exception))
+    if (!promise.try_set_exception(exception, ignore))
     {
         throw std::runtime_error{ "Precondition failed." };
     }
@@ -951,9 +1696,10 @@ TEST_CASE("task_completion_source<T&>.try_set_exception() resumes a coroutine su
     async::event_signal done{};
     co_await_value_finally_set_signal(promise.task(), done);
     std::exception_ptr exception{ std::make_exception_ptr(std::runtime_error{ "" }) };
+    std::exception_ptr ignore{};
 
     // Act
-    if (!promise.try_set_exception(exception))
+    if (!promise.try_set_exception(exception, ignore))
     {
         throw std::runtime_error{ "Precondition failed." };
     }
@@ -969,9 +1715,10 @@ TEST_CASE("task_completion_source<T&>.try_set_exception() makes its task throw o
     async::task<int&> task{ promise.task() };
     std::runtime_error expected{ "expected" };
     std::exception_ptr exception{ std::make_exception_ptr(expected) };
+    std::exception_ptr ignore{};
 
     // Act
-    if (!promise.try_set_exception(exception))
+    if (!promise.try_set_exception(exception, ignore))
     {
         throw std::runtime_error{ "Precondition failed." };
     }
@@ -986,13 +1733,15 @@ TEST_CASE("task_completion_source<T&>.try_set_exception() returns false if calle
     async::task_completion_source<int&> promise{};
     async::task<int&> task{ promise.task() };
     std::exception_ptr exception{ std::make_exception_ptr(std::runtime_error{ "" }) };
-    if (!promise.try_set_exception(exception))
+    std::exception_ptr ignore{};
+
+    if (!promise.try_set_exception(exception, ignore))
     {
         throw std::runtime_error{ "Precondition failed." };
     }
 
     // Act
-    bool result{ promise.try_set_exception(exception) };
+    bool result{ promise.try_set_exception(exception, ignore) };
 
     // Assert
     REQUIRE(!result);
@@ -1077,9 +1826,10 @@ TEST_CASE("task_completion_source<T>.try_set_value() returns false when another 
     async::event_signal ignore2{};
     doNotBlock.set();
     startedMove.wait_for_or_throw(std::chrono::seconds{ 1 });
+    std::exception_ptr ignore3{};
 
     // Act
-    bool result{ promise.try_set_value(move_only_signal_and_block_on_move{ ignore1, doNotBlock, ignore2 }) };
+    bool result{ promise.try_set_value(move_only_signal_and_block_on_move{ ignore1, doNotBlock, ignore2 }, ignore3) };
 
     // Assert
     resumeMove.set();


### PR DESCRIPTION
Cleanup use of noexcept.

Use noexcept if and only if calling noexcept functions (unless commeted reasons exist for doing otherwise).
Add new try_* overloads to task_completion_source to handle noexcept correctly.