### PR TITLE
Fix typo in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -210,7 +210,7 @@ int main()
 For implementations that wish to treat cancellation as exceptional, this exception type can be thrown to indicate that
 a task responded to a cancellation request rather than completing successfully.
 
-Alternatives to exceptions include returning a sentinel value or using std::excepted (C++23). For details, see
+Alternatives to exceptions include returning a sentinel value or using std::expected (C++23). For details, see
 the Cancellation section below.
 
 Example usage:


### PR DESCRIPTION
std::excepted --> std::expected

I also found a typo in the code example for [task_completion_source](https://github.com/microsoft/cpp-async#task_completion_source): `the may run and be destroyed` but I'm not 100% sure which word is missing here.