### PR TITLE
Fix capture of move-only awaitables.

### DIFF
--- a/include/async/awaitable_get.h
+++ b/include/async/awaitable_get.h
@@ -124,7 +124,11 @@ namespace async
 
         struct factory final
         {
-            static details::get_task<T> create(Awaitable awaitable) { co_return co_await std::move(awaitable); }
+            static details::get_task<T> create(Awaitable awaitable)
+            {
+                Awaitable capturedAwaitable{ std::move(awaitable) };
+                co_return co_await std::move(capturedAwaitable);
+            }
         };
 
         return factory::create(std::move(awaitable)).get();

--- a/include/async/awaitable_then.h
+++ b/include/async/awaitable_then.h
@@ -26,11 +26,12 @@ namespace async::details
     {
         static then_task create(Awaitable awaitable, Continuation continuation)
         {
+            Awaitable capturedAwaitable{ std::move(awaitable) };
             awaitable_result<T> result{};
 
             try
             {
-                result.set_value(co_await std::move(awaitable));
+                result.set_value(co_await std::move(capturedAwaitable));
             }
             catch (...)
             {
@@ -47,11 +48,12 @@ namespace async::details
     {
         static then_task create(Awaitable awaitable, Continuation continuation)
         {
+            Awaitable capturedAwaitable{ std::move(awaitable) };
             std::exception_ptr exception{};
 
             try
             {
-                co_await std::move(awaitable);
+                co_await std::move(capturedAwaitable);
             }
             catch (...)
             {

--- a/include/async/to_future.h
+++ b/include/async/to_future.h
@@ -25,12 +25,13 @@ namespace async::details
     {
         static to_future_task create(Awaitable awaitable, std::future<T>& future)
         {
+            Awaitable capturedAwaitable{ std::move(awaitable) };
             std::promise<T> promise{};
             future = promise.get_future();
 
             try
             {
-                promise.set_value(co_await std::move(awaitable));
+                promise.set_value(co_await std::move(capturedAwaitable));
             }
             catch (...)
             {
@@ -46,6 +47,7 @@ namespace async::details
     {
         static to_future_task create(Awaitable awaitable, std::future<void>& future)
         {
+            Awaitable capturedAwaitable{ std::move(awaitable) };
             std::promise<void> promise{};
             future = promise.get_future();
 
@@ -53,7 +55,7 @@ namespace async::details
 
             try
             {
-                co_await awaitable;
+                co_await std::move(capturedAwaitable);
             }
             catch (...)
             {

--- a/test/task_completion_source_tests.cpp
+++ b/test/task_completion_source_tests.cpp
@@ -36,9 +36,11 @@ namespace
 {
     async::task<void> co_await_void_finally_set_signal(async::task<void>&& awaitable, async::event_signal& done)
     {
+        async::task<void> capturedAwaitable{ std::move(awaitable) };
+
         try
         {
-            co_await std::move(awaitable);
+            co_await std::move(capturedAwaitable);
         }
         catch (...)
         {
@@ -206,9 +208,11 @@ namespace
     co_await_void_propagates_unhandled_exception_task co_await_void_propagates_unhandled_exception(
         async::task<void>&& awaitable, std::exception_ptr exception)
     {
+        async::task<void> capturedAwaitable{ std::move(awaitable) };
+
         try
         {
-            co_await std::move(awaitable);
+            co_await std::move(capturedAwaitable);
         }
         catch (...)
         {
@@ -729,9 +733,11 @@ namespace
     template <typename T>
     async::task<void> co_await_value_finally_set_signal(async::task<T>&& awaitable, async::event_signal& done)
     {
+        async::task<T> capturedAwaitable{ std::move(awaitable) };
+
         try
         {
-            (void)(co_await std::move(awaitable));
+            (void)(co_await std::move(capturedAwaitable));
         }
         catch (...)
         {
@@ -908,11 +914,12 @@ namespace
     co_await_value_propagates_unhandled_exception_task co_await_value_propagates_unhandled_exception(
         async::task<int>&& awaitable, std::exception_ptr exception)
     {
+        async::task<int> capturedAwaitable{ std::move(awaitable) };
         int ignore{};
 
         try
         {
-            ignore = co_await std::move(awaitable);
+            ignore = co_await std::move(capturedAwaitable);
         }
         catch (...)
         {


### PR DESCRIPTION
Per discussion with the MSVC compiler team, we were incorrectly using a reference beyond its lifetime, and capturing the awaitable before suspending it resolves this problem.

With this fix, tests now pass on all architectures and configurations (x64 and x86, Debug and Release).